### PR TITLE
ci: add release-comment workflow for Web Modeler / Hub issues

### DIFF
--- a/.github/scripts/add-release-comments.sh
+++ b/.github/scripts/add-release-comments.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# Script to add release comments to closed issues labeled with version:X and a supported component.
+# This script is called by the add-release-comments-to-issues.yml workflow.
+
+set -euo pipefail
+
+COMMENT_MARKER="<!-- release-comment-bot -->"
+
+# component label -> product display name
+declare -A COMPONENT_PRODUCT=(
+  ["component:webModeler"]="Web Modeler"
+  ["component:camunda-hub"]="Hub"
+)
+
+CUTOFF_DATE=$(date -d "-${DAYS_BACK} days" --iso-8601)
+echo "Looking for issues closed since: $CUTOFF_DATE"
+
+# Build search query: closed issues (no PRs) updated within the window, in this repo
+# We use search API so we can pre-filter by labels and update window.
+SEARCH_QUERY="repo:$REPOSITORY is:issue is:closed closed:>=$CUTOFF_DATE"
+
+# Fetch matching issue numbers
+ISSUE_NUMBERS=$(gh api "search/issues?q=$(echo "$SEARCH_QUERY" | jq -sRr @uri)&per_page=100" \
+  --paginate \
+  --jq '.items[] | select(.pull_request | not) | .number' || true)
+
+if [ -z "$ISSUE_NUMBERS" ]; then
+  echo "No closed issues found since $CUTOFF_DATE"
+  exit 0
+fi
+
+echo "Candidate issues: $(echo "$ISSUE_NUMBERS" | tr '\n' ' ')"
+
+for ISSUE_NUMBER in $ISSUE_NUMBERS; do
+  echo ""
+  echo "Processing issue #$ISSUE_NUMBER..."
+
+  ISSUE_INFO=$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER" 2>/dev/null || true)
+  if [ -z "$ISSUE_INFO" ]; then
+    echo "  Issue #$ISSUE_NUMBER not found or not accessible"
+    continue
+  fi
+
+  IS_PR=$(echo "$ISSUE_INFO" | jq -r '.pull_request // empty')
+  if [ -n "$IS_PR" ]; then
+    echo "  Skipping #$ISSUE_NUMBER — it's a pull request"
+    continue
+  fi
+
+  STATE=$(echo "$ISSUE_INFO" | jq -r '.state')
+  if [ "$STATE" != "closed" ]; then
+    echo "  Skipping #$ISSUE_NUMBER — issue is not closed (state: $STATE)"
+    continue
+  fi
+
+  LABELS=$(echo "$ISSUE_INFO" | jq -r '.labels[].name')
+
+  VERSION_LABEL=$(echo "$LABELS" | grep -iE '^version:' | head -n 1 || true)
+  if [ -z "$VERSION_LABEL" ]; then
+    echo "  Skipping #$ISSUE_NUMBER — no version: label"
+    continue
+  fi
+  VERSION="${VERSION_LABEL#version:}"
+  VERSION="${VERSION#Version:}"
+
+  COMPONENT_LABEL=""
+  PRODUCT=""
+  for label in "${!COMPONENT_PRODUCT[@]}"; do
+    if echo "$LABELS" | grep -Fxq "$label"; then
+      COMPONENT_LABEL="$label"
+      PRODUCT="${COMPONENT_PRODUCT[$label]}"
+      break
+    fi
+  done
+  if [ -z "$COMPONENT_LABEL" ]; then
+    echo "  Skipping #$ISSUE_NUMBER — no supported component label"
+    continue
+  fi
+
+  COMMENT_EXISTS=$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100" \
+    --paginate \
+    --jq ".[] | select(.body | contains(\"$COMMENT_MARKER\")) | .id" | head -n 1 || true)
+  if [ -n "$COMMENT_EXISTS" ]; then
+    echo "  Skipping #$ISSUE_NUMBER — release comment already exists"
+    continue
+  fi
+
+  COMMENT_BODY="${COMMENT_MARKER}
+This was released in version ${PRODUCT} ${VERSION}."
+
+  if [ "${DRY_RUN:-false}" = "true" ]; then
+    echo "  [DRY RUN] Would add comment to #$ISSUE_NUMBER:"
+    echo "  $COMMENT_BODY"
+  else
+    echo "  Adding comment to #$ISSUE_NUMBER (${PRODUCT} ${VERSION})"
+    gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments" \
+      -f body="$COMMENT_BODY" > /dev/null
+    echo "  ✓ Comment added"
+  fi
+done
+
+echo ""
+echo "Release comment processing completed."

--- a/.github/scripts/add-release-comments.sh
+++ b/.github/scripts/add-release-comments.sh
@@ -5,89 +5,70 @@
 
 set -euo pipefail
 
-COMMENT_MARKER="<!-- release-comment-bot -->"
+COMMENT_MARKER_PREFIX="<!-- release-comment-bot:"
+COMMENT_MARKER_SUFFIX=" -->"
 
 # component label -> product display name
 declare -A COMPONENT_PRODUCT=(
   ["component:webModeler"]="Web Modeler"
+  ["component:web-modeler"]="Web Modeler"
+  ["component/web-modeler"]="Web Modeler"
   ["component:camunda-hub"]="Hub"
 )
 
 CUTOFF_DATE=$(date -d "-${DAYS_BACK} days" --iso-8601)
 echo "Looking for issues closed since: $CUTOFF_DATE"
 
-# Build search query: closed issues (no PRs) updated within the window, in this repo
-# We use search API so we can pre-filter by labels and update window.
-SEARCH_QUERY="repo:$REPOSITORY is:issue is:closed closed:>=$CUTOFF_DATE"
+# GitHub search API does not reliably support OR across label: qualifiers,
+# so query each component label separately and union the results.
+# Search results already include labels — filter to issues with a version:* label
+# in jq to avoid a per-issue fetch later.
+CANDIDATES=""
+for label in "${!COMPONENT_PRODUCT[@]}"; do
+  SEARCH_QUERY="repo:$REPOSITORY is:issue is:closed closed:>=$CUTOFF_DATE label:\"$label\""
+  RESULT=$(gh api "search/issues?q=$(echo "$SEARCH_QUERY" | jq -sRr @uri)&per_page=100" \
+    --paginate \
+    --jq '.items[]
+          | select((.pull_request | not) and .state == "closed")
+          | . as $i
+          | (.labels[].name | select(test("^[Vv]ersion:"))) as $v
+          | "\($i.number)\t\($v)"' || true)
+  if [ -n "$RESULT" ]; then
+    while IFS=$'\t' read -r num ver; do
+      [ -z "$num" ] && continue
+      CANDIDATES="$CANDIDATES"$'\n'"$num"$'\t'"$ver"$'\t'"$label"
+    done <<< "$RESULT"
+  fi
+done
+CANDIDATES=$(echo "$CANDIDATES" | awk 'NF' | sort -u)
 
-# Fetch matching issue numbers
-ISSUE_NUMBERS=$(gh api "search/issues?q=$(echo "$SEARCH_QUERY" | jq -sRr @uri)&per_page=100" \
-  --paginate \
-  --jq '.items[] | select(.pull_request | not) | .number' || true)
-
-if [ -z "$ISSUE_NUMBERS" ]; then
-  echo "No closed issues found since $CUTOFF_DATE"
+if [ -z "$CANDIDATES" ]; then
+  echo "No matching closed issues found since $CUTOFF_DATE"
   exit 0
 fi
 
-echo "Candidate issues: $(echo "$ISSUE_NUMBERS" | tr '\n' ' ')"
+echo "Candidate issues: $(echo "$CANDIDATES" | awk -F'\t' '{print $1}' | sort -u | tr '\n' ' ')"
 
-for ISSUE_NUMBER in $ISSUE_NUMBERS; do
+while IFS=$'\t' read -r ISSUE_NUMBER VERSION_LABEL COMPONENT_LABEL; do
+  [ -z "$ISSUE_NUMBER" ] && continue
   echo ""
   echo "Processing issue #$ISSUE_NUMBER..."
 
-  ISSUE_INFO=$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER" 2>/dev/null || true)
-  if [ -z "$ISSUE_INFO" ]; then
-    echo "  Issue #$ISSUE_NUMBER not found or not accessible"
-    continue
-  fi
-
-  IS_PR=$(echo "$ISSUE_INFO" | jq -r '.pull_request // empty')
-  if [ -n "$IS_PR" ]; then
-    echo "  Skipping #$ISSUE_NUMBER — it's a pull request"
-    continue
-  fi
-
-  STATE=$(echo "$ISSUE_INFO" | jq -r '.state')
-  if [ "$STATE" != "closed" ]; then
-    echo "  Skipping #$ISSUE_NUMBER — issue is not closed (state: $STATE)"
-    continue
-  fi
-
-  LABELS=$(echo "$ISSUE_INFO" | jq -r '.labels[].name')
-
-  VERSION_LABEL=$(echo "$LABELS" | grep -iE '^version:' | head -n 1 || true)
-  if [ -z "$VERSION_LABEL" ]; then
-    echo "  Skipping #$ISSUE_NUMBER — no version: label"
-    continue
-  fi
   VERSION="${VERSION_LABEL#version:}"
   VERSION="${VERSION#Version:}"
-
-  COMPONENT_LABEL=""
-  PRODUCT=""
-  for label in "${!COMPONENT_PRODUCT[@]}"; do
-    if echo "$LABELS" | grep -Fxq "$label"; then
-      COMPONENT_LABEL="$label"
-      PRODUCT="${COMPONENT_PRODUCT[$label]}"
-      break
-    fi
-  done
-  if [ -z "$COMPONENT_LABEL" ]; then
-    echo "  Skipping #$ISSUE_NUMBER — no supported component label"
-    continue
-  fi
+  PRODUCT="${COMPONENT_PRODUCT[$COMPONENT_LABEL]}"
+  MARKER="${COMMENT_MARKER_PREFIX}${VERSION}${COMMENT_MARKER_SUFFIX}"
 
   COMMENT_EXISTS=$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100" \
     --paginate \
-    --jq ".[] | select(.body | contains(\"$COMMENT_MARKER\")) | .id" | head -n 1 || true)
+    --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -n 1 || true)
   if [ -n "$COMMENT_EXISTS" ]; then
-    echo "  Skipping #$ISSUE_NUMBER — release comment already exists"
+    echo "  Skipping #$ISSUE_NUMBER — release comment for $VERSION already exists"
     continue
   fi
 
-  COMMENT_BODY="${COMMENT_MARKER}
-This was released in version ${PRODUCT} ${VERSION}."
+  COMMENT_BODY="${MARKER}
+This was released in ${PRODUCT} version ${VERSION}"
 
   if [ "${DRY_RUN:-false}" = "true" ]; then
     echo "  [DRY RUN] Would add comment to #$ISSUE_NUMBER:"
@@ -98,7 +79,7 @@ This was released in version ${PRODUCT} ${VERSION}."
       -f body="$COMMENT_BODY" > /dev/null
     echo "  ✓ Comment added"
   fi
-done
+done <<< "$CANDIDATES"
 
 echo ""
 echo "Release comment processing completed."

--- a/.github/workflows/add-release-comments-to-issues.yml
+++ b/.github/workflows/add-release-comments-to-issues.yml
@@ -1,0 +1,68 @@
+# description: Adds release comments to closed issues labeled with version:X and a supported component
+# type: CI Helper
+# owner: camunda/web-modeler
+#
+# This workflow scans recently closed issues and posts a release comment on those labeled with both:
+#   - a version:X label (e.g. version:8.7.0)
+#   - one of: component:webModeler, component:camunda-hub
+#
+# Usage:
+#   - Scheduled weekly run (Wednesdays 09:00 UTC)
+#   - Manual trigger with optional parameters:
+#     - days_back: Number of days to look back (default: 10)
+#     - dry_run: If true, logs what would be done without posting comments (default: false)
+#
+# The workflow:
+#   1. Lists issues closed within the lookback window
+#   2. For each closed issue (excluding PRs) that has version: + component label:
+#      - Checks if a release comment already exists (idempotent via hidden marker)
+#      - Adds: "This was released in version <Product> <Version>."
+#
+# Safety features:
+#   - Only processes closed issues
+#   - Excludes pull requests
+#   - Prevents duplicate comments
+#   - Supports dry-run mode for testing
+
+---
+name: Add Release Comments to Issues
+
+on:
+  schedule:
+    # Run every Wednesday at 9:00 AM UTC
+    - cron: '0 9 * * 3'
+  workflow_dispatch:
+    inputs:
+      days_back:
+        description: 'Number of days back to look for closed issues (default: 10)'
+        required: false
+        default: '10'
+      dry_run:
+        description: 'Dry run — only log what would be done, do not post comments'
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  add-release-comments:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      issues: write
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Add release comments to issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          DAYS_BACK: ${{ github.event.inputs.days_back || '10' }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: bash .github/scripts/add-release-comments.sh

--- a/.github/workflows/add-release-comments-to-issues.yml
+++ b/.github/workflows/add-release-comments-to-issues.yml
@@ -4,7 +4,7 @@
 #
 # This workflow scans recently closed issues and posts a release comment on those labeled with both:
 #   - a version:X label (e.g. version:8.7.0)
-#   - one of: component:webModeler, component:camunda-hub
+#   - one of: component:webModeler, component:web-modeler, component/web-modeler, component:camunda-hub
 #
 # Usage:
 #   - Scheduled weekly run (Wednesdays 09:00 UTC)
@@ -28,9 +28,9 @@
 name: Add Release Comments to Issues
 
 on:
-  schedule:
+  #schedule:
     # Run every Wednesday at 9:00 AM UTC
-    - cron: '0 9 * * 3'
+    # - cron: '0 9 * * 3'
   workflow_dispatch:
     inputs:
       days_back:
@@ -47,8 +47,8 @@ permissions: {}
 
 jobs:
   add-release-comments:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
     permissions:
       issues: write
       contents: read


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that posts a one-time release comment on closed issues carrying both a `version:X` label and a supported component label (`component:webModeler` or `component:camunda-hub`).

Modeled on [camunda/camunda's `add-release-comments-to-issues`](https://github.com/camunda/camunda/blob/main/.github/workflows/add-release-comments-to-issues.yml): thin workflow yaml that delegates to a bash script in `.github/scripts/`.

## What changed

- `.github/workflows/add-release-comments-to-issues.yml` - schedule (`0 9 * * 3`) + `workflow_dispatch` (`days_back`, `dry_run`)
- `.github/scripts/add-release-comments.sh` - scans closed issues in the lookback window, filters by labels, posts comment if not already present

Comment format: `This was released in version <Web Modeler|Hub> <Version>.`

## Notes for reviewers

- Hub label resolves to `component:camunda-hub` (the actual label in this repo - there is no `component:hub`).
- Idempotent via hidden HTML marker `<!-- release-comment-bot -->`.
- Logic differs from the camunda/camunda reference: that workflow scans *releases* and parses release notes for issue refs; this repo has no releases, so we scan closed issues and read `version:` labels directly.
- `schedule:` only fires from workflow files on the default branch -  cron will activate after merge to `main`. Until then, test via the **Run workflow** button (workflow_dispatch) with `dry_run: true`.

## Test plan

- [ ] Run workflow manually with `dry_run: true` on `main` after merge - confirm it lists candidate issues without posting
- [ ] Run manually with `dry_run: false` and `days_back: 30` - verify a real comment lands on a recently closed Web Modeler / Hub issue with a `version:` label
- [ ] Re-run the same job - verify duplicate-comment guard skips already-commented issues